### PR TITLE
stringx:

### DIFF
--- a/stringx/convert.go
+++ b/stringx/convert.go
@@ -1,0 +1,34 @@
+// Copyright 2023 chenmingyong0423
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stringx
+
+import (
+	"strings"
+	"unicode"
+)
+
+// CamelToSnake 驼峰命名转成蛇形命名，如果不是驼峰命名，则转成对应小写字符串
+// UserAgent → user_agent
+// User → user
+func CamelToSnake(camelCase string) string {
+	var result strings.Builder
+	for i, c := range camelCase {
+		if unicode.IsUpper(c) && i > 0 {
+			result.WriteByte('_')
+		}
+		result.WriteRune(unicode.ToLower(c))
+	}
+	return result.String()
+}

--- a/stringx/convert_test.go
+++ b/stringx/convert_test.go
@@ -1,0 +1,60 @@
+// Copyright 2023 chenmingyong0423
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stringx
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCamelToSnake(t *testing.T) {
+	testCases := []struct {
+		name      string
+		camelCase string
+
+		want string
+	}{
+		{
+			name:      "empty string",
+			camelCase: "",
+
+			want: "",
+		},
+		{
+			name:      "Not camel string",
+			camelCase: "User",
+
+			want: "user",
+		},
+		{
+			name:      "Camel string",
+			camelCase: "UserAgent",
+
+			want: "user_agent",
+		},
+		{
+			name:      "Complex camel string",
+			camelCase: "MyUserAgent",
+
+			want: "my_user_agent",
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			snake := CamelToSnake(tt.camelCase)
+			assert.Equal(t, tt.want, snake)
+		})
+	}
+}


### PR DESCRIPTION
- 新增 CamelToSnake 函数，驼峰命名转成蛇形命名，如果不是驼峰命名，则转成对应小写字符串